### PR TITLE
Add /blog to baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,14 +45,14 @@ google_analytics: UA-153801665-1
 
 # Your website URL (e.g. http://amitmerchant1990.github.io or http://www.amitmerchant.com)
 # Used for Sitemap.xml and your RSS feed
-url: https://petermarshall.github.io/blog/
-enforce_ssl: https://petermarshall.github.io/blog/
+url: https://petermarshall.github.io
+enforce_ssl: https://petermarshall.github.io
 
 # If you're hosting your site at a Project repository on GitHub pages
 # (http://yourusername.github.io/repository-name)
 # and NOT your User repository (http://yourusername.github.io)
 # then add in the baseurl here, like this: "/repository-name"
-baseurl: "/"
+baseurl: "/blog"
 
 #
 # !! You don't need to change any of the configuration flags below !!


### PR DESCRIPTION
Add '/blog' to the baseurl, and remove it from the main url, should prevent quirky '/blog//blog/' paths being generated on build.